### PR TITLE
chef/chefdk:4 doesn't exist

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -3,7 +3,7 @@ version: 2.1
 
 executors:
   delivery:
-    docker: [image: "chef/chefdk:4"]
+    docker: [image: "chef/chefdk:4.0.5"]
   ruby:
     docker: [image: "circleci/ruby"]
   python:


### PR DESCRIPTION
# Description

https://hub.docker.com/r/chef/chefdk/tags/

## Issues Resolved

[List any existing issues this PR resolves]

## Check List

- [ ] All tests pass. See TESTING.md for details
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
