### PR TITLE
Update Chefdk to v4.4.41

### DIFF
--- a/kitchen/orb.yml
+++ b/kitchen/orb.yml
@@ -3,7 +3,7 @@ version: 2.1
 
 executors:
   chefdk:
-    docker: [image: "chef/chefdk:4.4.9"]
+    docker: [image: "chef/chefdk:4.4.41"]
   ruby:
     docker: [image: "circleci/ruby"]
   python:


### PR DESCRIPTION
# Description

Use latest chefdk version so we can use latest inspec version (this contains a fix for apt package assertions needed for the postgresql package).

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
