### PR TITLE
Fix line continuation for 'docker network create' in dokken-single

### DIFF
--- a/kitchen/orb.yml
+++ b/kitchen/orb.yml
@@ -129,7 +129,7 @@ jobs:
       - when:
           condition: << parameters.enable-ipv6 >>
           steps:
-            - run: |
+            - run: >
                 docker network create --driver=bridge
                 --subnet=172.18.0.0/16 --gateway=172.18.0.1
                 --subnet=2001:db8:1::/64 --ipv6 dokken


### PR DESCRIPTION
# Description

As title.

## Issues Resolved

CircleCI tests with IPv6 currently fail on a bad docker command <https://app.circleci.com/pipelines/github/sous-chefs/dhcp/121/workflows/081759e6-4945-4d7f-9594-01dc6cd98331/jobs/439>.

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
